### PR TITLE
Improvement of helm chart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,9 @@ Essential/files/iTop-essential-docker.tar.gz
 # ignore iTop Professional source and builds
 Professional/files/iTop Professional-*.zip
 Professional/files/iTop-professional-docker.tar.gz
+
+# ignore helm build`s artifacts
+helm-chart/charts
+helm-chart/Chart.lock
+
+tmp

--- a/helm-chart/Chart.yaml
+++ b/helm-chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: itop-chart
-description: Itop Helm chart 
+description: Itop Helm chart
 
 # A chart can be either an 'application' or a 'library' chart.
 #
@@ -15,10 +15,16 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "3.0.0"
+appVersion: "3.1"
+
+dependencies:
+  - condition: mariadb.enabled
+    name: mariadb
+    repository: https://charts.bitnami.com/bitnami
+    version: ~14.1.4

--- a/helm-chart/README.md
+++ b/helm-chart/README.md
@@ -10,17 +10,13 @@ You can check the [template](./templates/pvc.yaml) for more info.
 
 The folders that are saved are specified in the [deployment.yaml](./templates/deployment.yaml) file :
 
-```yaml
-volumeMounts:
-  - mountPath: "/var/www/html/data"
-    name: itop-data-pv
-  - mountPath: "/var/www/html/env-production"
-    name: itop-env-pv
-  - mountPath: "/var/www/html/log"
-    name: itop-log-pv
-  - mountPath: "/var/www/html/conf"
-    name: itop-conf-pv
-```
+- conf
+- data
+- env-production
+- extensions
+- log
+
+Chart support using separate PV for each folder, or it can be used one PV (`pvc.useOnePV: true`).
 
 ## Values.yaml
 
@@ -62,6 +58,33 @@ You can create a configmap and add it to the pod deployment in order to have the
 
 This is not recommended.
 
-## What is not added
+## Installation
 
-A MySQL/MariaDB chart link in order to also have a db deployed to go with the iTop instance.
+if it is installation from scratch, it is necessary to disable all probes in pod,
+because probes can be failed while install:
+
+```yaml
+startupProbe:
+  enabled: false
+
+readinessProbe:
+  enabled: false
+
+livenessProbe:
+  enabled: false
+```
+
+After deploying release, open browser at <your_itop_url>/setup
+and follow the installation steps.
+
+After the installation is finished, the probes can be enabled again.
+
+## Upgrade
+
+- disable POD's probes
+
+- deploy release with newer tag
+
+- open browser at <your_itop_url>/setup and follow the upgrade wizard
+
+After the upgrade is finished, the probes can be enabled again.

--- a/helm-chart/templates/configmap.yaml
+++ b/helm-chart/templates/configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "itop-chart.fullname" . }}-cm
+data:
+  php.ini: | {{ .Values.phpConfig | nindent 4 }}

--- a/helm-chart/templates/deployment-cron.yaml
+++ b/helm-chart/templates/deployment-cron.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "itop-chart.fullname" . }}-cron
+  labels:
+    {{- include "itop-chart.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "itop-chart.selectorLabels" . | nindent 6 }}
+      itop-component: cron
+  template:
+    metadata:
+      {{- with .Values.cron.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "itop-chart.selectorLabels" . | nindent 8 }}
+        itop-component: cron
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "itop-chart.serviceAccountName" . }}
+      securityContext: {{- .Values.podSecurityContext | toYaml | nindent 8 }}
+      containers:
+        - name: cron-{{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: "USER"
+              value: {{ .Values.cron.user | quote }}
+            - name: "PASSWORD"
+              value: {{ .Values.cron.password | quote}}
+            - name: "INTERVAL"
+              value: {{ .Values.cron.interval | quote }}
+          command: ["bash"]
+          args:
+            - "-c"
+            - |
+                while true; do
+                    echo -n $(date +"[%m-%d %H:%M:%S]")" | "
+                    START_TIME=${SECONDS};
+                    curl --connect-timeout 3 --user ${USER}:${PASSWORD} "{{ include "itop-chart.fullname" . }}/webservices/cron.php" -sS | grep '<p>';
+                    DURATION=$(( ${SECONDS} - ${START_TIME} ));
+                    [ ${DURATION} -lt ${INTERVAL} ] && sleep $(( ${INTERVAL} - ${DURATION} ));
+                done
+          resources:
+            {{- toYaml .Values.cron.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm-chart/templates/deployment.yaml
+++ b/helm-chart/templates/deployment.yaml
@@ -15,6 +15,7 @@ spec:
   selector:
     matchLabels:
       {{- include "itop-chart.selectorLabels" . | nindent 6 }}
+      itop-component: web
   template:
     metadata:
       {{- with .Values.podAnnotations }}
@@ -23,15 +24,27 @@ spec:
       {{- end }}
       labels:
         {{- include "itop-chart.selectorLabels" . | nindent 8 }}
+        itop-component: web
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "itop-chart.serviceAccountName" . }}
-      securityContext:
-        fsGroup: 33
+      securityContext: {{- .Values.podSecurityContext | toYaml | nindent 8 }}
       volumes:
+        - name: cm
+          configMap:
+            name: {{ include "itop-chart.fullname" . }}-cm
+      {{- with .Values.extraVolumes }}
+      {{- . | toYaml | nindent 8 }}
+      {{- end }}
+      {{- if .Values.pvc.enabled }}
+      {{- if .Values.pvc.useOnePV }}
+        - name: itop-pv
+          persistentVolumeClaim:
+            claimName: itop-pv
+      {{- else }}
         - name: itop-conf-pv
           persistentVolumeClaim:
             claimName: itop-conf-pvc
@@ -43,7 +56,14 @@ spec:
             claimName: itop-env-pvc
         - name: itop-log-pv
           persistentVolumeClaim:
-            claimName: itop-log-pvc   
+            claimName: itop-log-pvc
+        {{- if .Values.pvc.extensions.enabled }}
+        - name: itop-extensions-pv
+          persistentVolumeClaim:
+            claimName: itop-extensions-pvc
+        {{- end }}
+      {{- end }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -51,14 +71,31 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           volumeMounts:
+            - name: cm
+              mountPath: /usr/local/etc/php/conf.d/php.ini
+              subPath: php.ini
+            {{- if .Values.pvc.enabled }}
             - mountPath: "/var/www/html/data"
-              name: itop-data-pv
+              name: {{ ternary "itop-pv" "itop-data-pv" .Values.pvc.useOnePV }}
+              subPath: {{ ternary "data" "" .Values.pvc.useOnePV }}
             - mountPath: "/var/www/html/env-production"
-              name: itop-env-pv
+              name: {{ ternary "itop-pv" "itop-env-pv" .Values.pvc.useOnePV }}
+              subPath: {{ ternary "env-production" "" .Values.pvc.useOnePV }}
             - mountPath: "/var/www/html/log"
-              name: itop-log-pv
+              name: {{ ternary "itop-pv" "itop-log-pv" .Values.pvc.useOnePV }}
+              subPath: {{ ternary "log" "" .Values.pvc.useOnePV }}
             - mountPath: "/var/www/html/conf"
-              name: itop-conf-pv
+              name: {{ ternary "itop-pv" "itop-conf-pv" .Values.pvc.useOnePV }}
+              subPath: {{ ternary "conf" "" .Values.pvc.useOnePV }}
+            {{- if .Values.pvc.extensions.enabled }}
+            - mountPath: "/var/www/html/extensions"
+              name: {{ ternary "itop-pv" "itop-extensions-pv" .Values.pvc.useOnePV }}
+              subPath: {{ ternary "extensions" "" .Values.pvc.useOnePV }}
+            {{- end }}
+            {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- .| toYaml | nindent 12 }}
+            {{- end }}
           env:
             - name: "DB_ENV_MYSQL_DATABASE"
               value: {{ .Values.environment.db_name}}
@@ -68,20 +105,56 @@ spec:
               value: {{ .Values.environment.db_user}}
             - name: "DB_ENV_MYSQL_PASSWORD"
               value: {{ .Values.environment.db_pwd}}
+            - name: "DB_PREFIX"
+              value: {{ .Values.environment.db_prefix}}
           ports:
             - name: http
               containerPort: {{ .Values.container.port }}
               protocol: TCP
+          {{- if .Values.startupProbe.enabled }}
+          startupProbe:
+            httpGet:
+              path: /webservices/status.php
+              port: http
+          {{- unset .Values.startupProbe "enabled" | toYaml | nindent 12 }}
+          {{- end }}
+          {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
               path: /webservices/status.php
               port: http
+          {{- unset .Values.livenessProbe "enabled" | toYaml | nindent 12 }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
               path: /webservices/status.php
               port: http
+          {{- unset .Values.readinessProbe "enabled" | toYaml | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+      {{- if and .Values.pvc.enabled .Values.mariadb.enabled }}
+      initContainers:
+        - name: init-config
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - 'bash'
+            - '-c'
+            - |
+              cd /var/www/html
+              if [ ! -e "confPV/production/config-itop.php" ];then
+                mkdir -p confPV/production
+                cp conf/production/config-itop.php confPV/production/
+                chown 33 confPV/production/config-itop.php
+              fi
+              exit 0
+          volumeMounts:
+            - mountPath: "/var/www/html/confPV"
+              name: {{ ternary "itop-pv" "itop-conf-pv" .Values.pvc.useOnePV }}
+              subPath: {{ ternary "conf" "" .Values.pvc.useOnePV }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm-chart/templates/extra-deploy.yaml
+++ b/helm-chart/templates/extra-deploy.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraDeploy }}
+---
+  {{- tpl ( . | toYaml) $ }}
+{{- end }}

--- a/helm-chart/templates/pvc.yaml
+++ b/helm-chart/templates/pvc.yaml
@@ -1,11 +1,31 @@
+{{- if .Values.pvc.enabled }}
+{{- if .Values.pvc.useOnePV }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: itop-pv
+  annotations: {{- .Values.pvc.commonAnnotations | toYaml | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.pvc.accessMode }}
+  {{- if  .Values.pvc.storageClassName }}
+  storageClassName: {{ .Values.pvc.storageClassName }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.pvc.data.size }}
+{{- else }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: itop-conf-pvc
+  annotations: {{- .Values.pvc.commonAnnotations | toYaml | nindent 4 }}
 spec:
   accessModes:
     - {{ .Values.pvc.accessMode }}
+  {{- if  .Values.pvc.storageClassName }}
   storageClassName: {{ .Values.pvc.storageClassName }}
+  {{- end }}
   resources:
     requests:
       storage: {{ .Values.pvc.conf.size }}
@@ -14,10 +34,13 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: itop-data-pvc
+  annotations: {{- .Values.pvc.commonAnnotations | toYaml | nindent 4 }}
 spec:
   accessModes:
     - {{ .Values.pvc.accessMode }}
+  {{- if  .Values.pvc.storageClassName }}
   storageClassName: {{ .Values.pvc.storageClassName }}
+  {{- end }}
   resources:
     requests:
       storage: {{ .Values.pvc.data.size }}
@@ -26,10 +49,13 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: itop-env-pvc
+  annotations: {{- .Values.pvc.commonAnnotations | toYaml | nindent 4 }}
 spec:
   accessModes:
     - {{ .Values.pvc.accessMode }}
+  {{- if  .Values.pvc.storageClassName }}
   storageClassName: {{ .Values.pvc.storageClassName }}
+  {{- end }}
   resources:
     requests:
       storage: {{ .Values.pvc.env.size }}
@@ -38,10 +64,33 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: itop-log-pvc
+  annotations: {{- .Values.pvc.commonAnnotations | toYaml | nindent 4 }}
 spec:
   accessModes:
     - {{ .Values.pvc.accessMode }}
+  {{- if  .Values.pvc.storageClassName }}
   storageClassName: {{ .Values.pvc.storageClassName }}
+  {{- end }}
   resources:
     requests:
       storage: {{ .Values.pvc.log.size }}
+apiVersion: v1
+
+{{- if .Values.pvc.extensions.enabled }}
+---
+kind: PersistentVolumeClaim
+metadata:
+  name: itop-extensions-pvc
+  annotations: {{- .Values.pvc.commonAnnotations | toYaml | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.pvc.accessMode }}
+  {{- if  .Values.pvc.storageClassName }}
+  storageClassName: {{ .Values.pvc.storageClassName }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.pvc.extensions.size }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/helm-chart/templates/service.yaml
+++ b/helm-chart/templates/service.yaml
@@ -13,3 +13,4 @@ spec:
       name: http
   selector:
     {{- include "itop-chart.selectorLabels" . | nindent 4 }}
+    itop-component: web

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -7,13 +7,14 @@ replicaCount: 1
 image:
   repository: supervisions/itop
   pullPolicy: Always
-  tag: 3.0
+  tag: 3.1
 
 environment:
-  db_host: <mysql-server-url> "mysql-chart.database.svc.cluster.local"
-  db_name: <mysql-db-name>
-  db_pwd: <mysql-db-pwd>
-  db_user: <mysql-db-user>
+  db_host: itop-mariadb # <address>:<port>
+  db_name: itop_db
+  db_pwd: itop_password
+  db_user: itop_user
+  db_prefix: ""
 
 imagePullSecrets: []
 nameOverride: ""
@@ -32,8 +33,8 @@ container:
   port: 80
 podAnnotations: {}
 
-podSecurityContext: {}
-  # fsGroup: 2000
+podSecurityContext:
+  fsGroup: 33
 
 securityContext: {}
   # capabilities:
@@ -44,8 +45,12 @@ securityContext: {}
   # runAsUser: 1000
 
 pvc:
+  enabled: true
+  useOnePV: false
   accessMode: ReadWriteOnce
-  storageClassName: standard
+  storageClassName: ""
+  commonAnnotations:
+    helm.sh/resource-policy: "keep"
   conf:
     size: 1Gi
   data:
@@ -53,6 +58,9 @@ pvc:
   env:
     size: 1Gi
   log:
+    size: 1Gi
+  extensions:
+    enabled: false
     size: 1Gi
 
 service:
@@ -63,8 +71,8 @@ service:
 ingress:
   enabled: true
   className: ""
-  annotations: 
-    traefik.ingress.kubernetes.io/router.tls: "true"
+  annotations: {}
+    # traefik.ingress.kubernetes.io/router.tls: "true"
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   hosts:
@@ -93,6 +101,19 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
+startupProbe:
+  enabled: true
+  failureThreshold: 30
+  periodSeconds: 3
+
+readinessProbe:
+  enabled: true
+  periodSeconds: 3
+
+livenessProbe:
+  enabled: true
+  periodSeconds: 3
+
 autoscaling:
   enabled: false
   minReplicas: 1
@@ -105,3 +126,32 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+extraVolumes: []
+
+extraVolumeMounts: []
+
+extraDeploy: []
+
+phpConfig: |
+  # [Core]
+  # error_reporting = E_ALL & ~E_DEPRECATED
+
+cron:
+  enabled: false
+  interval: 60
+  user: admin
+  password: changeMe
+  podAnnotations: {}
+  resources: {}
+
+# setting for mariaDB
+# ( default values: https://github.com/bitnami/charts/blob/main/bitnami/mariadb/values.yaml )
+
+mariadb:
+  enabled: false
+  auth:
+    database: itop_db
+    username: itop_user
+    password: itop_password
+    rootPassword: changeMe


### PR DESCRIPTION
- added mariadb sub chart as dependency to be able deploy maradb in release.

- added startupProbe probe

- added possibility to disable probes for itop deployment, it can be usefull for fresh install process.

- set default value of storageClassName to "" - it is best practice. And will be use default storage type for PV in this case.

- added possibility to use one PV instead of separate PV for each persistence folder.

- added additional PV for extensions folder within documentation of ITOP ver 3

- added install and upgrade notes to README.md